### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 ---
 # based on https://github.com/mvdan/github-actions-golang
 name: test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/exivity/pulumi-hcloud-k8s/security/code-scanning/1](https://github.com/exivity/pulumi-hcloud-k8s/security/code-scanning/1)

To address the issue, we need to explicitly define the permissions required for the workflow. Based on the tasks performed (checking out code, installing dependencies, linting, and testing), the workflow likely only requires read access to the repository contents.

The fix involves adding a `permissions` block at the root level of the workflow file. This block will define the least privileges necessary for the tasks performed in the workflow. Specifically, we will set `contents: read`, ensuring that the workflow can read the repository contents but does not have `write` access by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
