### PR TITLE
chore: Un-comment Cookiecutter installation and test steps in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Runs all tests
         run: make test
 
-      # - name: Install Cookiecutter
-      #   run: pip install cookiecutter
+      - name: Install Cookiecutter
+        run: pip install cookiecutter
 
-      # - name: Cookiecutter test
-      #   run: make test-cookiecutter
+      - name: Cookiecutter test
+        run: make test-cookiecutter


### PR DESCRIPTION
Re-enable the Cookiecutter installation and testing steps in the GitHub Actions workflow.