### PR TITLE
chore: Update documentation and remove lint target from Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ All Helm chart components are configured with sensible defaults but remain fully
 
 ## Requirements
 
+> **💡 Recommendation:** Create a dedicated Hetzner Cloud project for each cluster deployment to ensure proper resource isolation and billing separation.
+
 Install the following tools before using this project:
 
 - [Go](https://golang.org/) (for Pulumi program)
@@ -103,6 +105,8 @@ For Linux users, please refer to the official installation guides:
 - [talosctl](https://www.talos.dev/v1.10/talos-guides/install/talosctl/)
 
 ### Create a New Project
+
+> **💡 Recommendation:** Use a dedicated Hetzner Cloud project for each cluster deployment to ensure proper resource isolation and billing separation.
 
 ```sh
 cookiecutter https://github.com/exivity/pulumi-hcloud-k8s

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -32,9 +32,6 @@ talosctl: talosconfig ## Run talosctl for the current cluster
 download: ## Downloads the dependencies
 	@go mod download
 
-lint: fmt $(GOLANGCI_LINT) download ## Lints all code with golangci-lint
-	@go tool -modfile=golangci-lint.mod golangci-lint run
-
 fmt: ## Formats all code with go fmt
 	@go fmt ./...
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -139,7 +139,14 @@ make k9s
 Use talosctl to manage Talos nodes:
 
 ```sh
-make talosctl dashboard
+# Get cluster information
+make talosctl cluster show
+
+# Check cluster health  
+make talosctl health --server=false
+
+# View cluster resources
+make talosctl get members
 ```
 
 ### Common Operations
@@ -166,12 +173,16 @@ pulumi up
 
 - **k9s**: `make k9s` (recommended)
 - **kubectl**: `kubectl --kubeconfig ./{{ cookiecutter.pulumi_stack }}.kubeconfig.yml get pods -A`
-- **Talos Dashboard**: `make talosctl dashboard`
+- **Talos services**: `make talosctl services`
+- **Talos cluster info**: `make talosctl cluster show`
 
 #### Troubleshooting
 
-- **Check cluster status**: `make talosctl health`
-- **View cluster logs**: `make talosctl logs`
+- **Check cluster health**: `make talosctl health --server=false`
+- **Get cluster members**: `make talosctl get members`
+- **View system services**: `make talosctl services`
+- **Check node status**: `make talosctl get nodes`
+- **View cluster logs**: `make talosctl logs controller-runtime`
 - **Check Pulumi state**: `pulumi stack`
 
 For more configuration options, see the [Configuration Documentation](https://github.com/exivity/pulumi-hcloud-k8s/blob/main/docs/configuration.md).

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -58,10 +58,26 @@ This section covers how to manage your Kubernetes cluster deployment.
 
 ### Initial Setup
 
-1. Select your Pulumi stack:
+1. Initialize or select your Pulumi stack:
+
+   **For a new local stack:**
+
+   ```sh
+   pulumi stack init {{ cookiecutter.pulumi_stack }}
+   ```
+
+   **For a new organization stack:**
+
+   ```sh
+   pulumi stack init <org-name>/{{ cookiecutter.pulumi_stack }}
+   ```
+
+   **If the stack already exists, select it:**
 
    ```sh
    pulumi stack select {{ cookiecutter.pulumi_stack }}
+   # or for organization stacks:
+   pulumi stack select <org-name>/{{ cookiecutter.pulumi_stack }}
    ```
 
 2. Configure your Hetzner Cloud API tokens:


### PR DESCRIPTION
Enhance the README with resource isolation recommendations for Hetzner Cloud and clarify initial setup instructions for Pulumi stack initialization. Remove the lint target from the Makefile to streamline the build process.