### PR TITLE
chore: Update Pulumi configuration for CSI and tolerations

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -43,6 +43,20 @@ config:
           - key: "node-role.kubernetes.io/control-plane"
             operator: "Equal"
             effect: "NoSchedule"
+    csi:
+      enabled: true
+      version: 2.16.0
+      is_default_storage_class: true
+      reclaim_policy: Delete
+      encrypted_secret: randomString
+      values:
+        controller:
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: "Equal"
+              effect: "NoSchedule"
     cluster_auto_scaler:
       enabled: true
       version: 9.48.0

--- a/{{cookiecutter.project_slug}}/Pulumi.{{cookiecutter.pulumi_stack}}.yaml
+++ b/{{cookiecutter.project_slug}}/Pulumi.{{cookiecutter.pulumi_stack}}.yaml
@@ -46,14 +46,7 @@ config:
         controller:
           nodeSelector:
             node-role.kubernetes.io/control-plane: ""
-          additionalTolerations:
-            - key: "node-role.kubernetes.io/control-plane"
-              operator: "Equal"
-              effect: "NoSchedule"
-        node:
-          nodeSelector:
-            node-role.kubernetes.io/control-plane: ""
-          additionalTolerations:
+          tolerations:
             - key: "node-role.kubernetes.io/control-plane"
               operator: "Equal"
               effect: "NoSchedule"


### PR DESCRIPTION
Enhance the Pulumi configuration by enabling CSI and updating tolerations for the control plane nodes.