### PR TITLE
chore: Add CertLifetime field for kubeconfig certificate duration

### DIFF
--- a/pkg/config/talos.go
+++ b/pkg/config/talos.go
@@ -105,5 +105,5 @@ type TalosConfig struct {
 	// Defaults to "8760h" (1 year).
 	// Note: When modifying this value, it is recommended to also update K8sCertificateRenewalDuration
 	// to ensure certificates are renewed well before the kubeconfig expires.
-	CertLifetime *string `json:"cert_lifetime" validate:"omitempty,duration"`
+	CertLifetime *string `json:"cert_lifetime" validate:"omitempty"`
 }

--- a/pkg/config/talos.go
+++ b/pkg/config/talos.go
@@ -92,4 +92,18 @@ type TalosConfig struct {
 	// When set, Talos will enable encryption of Secret objects in etcd
 	// example creation: pulumi config set --path hcloud-k8s:talos.secretbox_encryption_secret --secret $(pwgen 32 1)
 	SecretboxEncryptionSecret *string `json:"secretbox_encryption_secret" validate:"omitempty,len=32"`
+
+	// CertLifetime is the admin kubeconfig certificate lifetime (default is 1 year).
+	// Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for ten minutes).
+	// Examples:
+	//
+	//	"24h"         - 24 hours (1 day)
+	//	"168h"        - 168 hours (7 days)
+	//	"720h"        - 720 hours (30 days)
+	//	"8760h"       - 8760 hours (1 year, default)
+	//
+	// Defaults to "8760h" (1 year).
+	// Note: When modifying this value, it is recommended to also update K8sCertificateRenewalDuration
+	// to ensure certificates are renewed well before the kubeconfig expires.
+	CertLifetime *string `json:"cert_lifetime" validate:"omitempty,duration"`
 }

--- a/pkg/talos/core/node-configuration.go
+++ b/pkg/talos/core/node-configuration.go
@@ -29,6 +29,8 @@ type NodeConfigurationArgs struct {
 	EnableLonghornSupport bool
 	// SecretboxEncryptionSecret is a base64-encoded 32-byte key used to encrypt Kubernetes secrets at rest in etcd
 	SecretboxEncryptionSecret *string
+	// CertLifetime is the admin kubeconfig certificate lifetime
+	CertLifetime *string
 	// AllowSchedulingOnControlPlanes is true if scheduling on control planes is allowed
 	AllowSchedulingOnControlPlanes bool
 	// Nameservers is the list of DNS servers to use for the cluster
@@ -41,6 +43,13 @@ type NodeConfigurationArgs struct {
 }
 
 func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) {
+	var adminKubeconfig *config.AdminKubeconfigConfig
+	if args.CertLifetime != nil {
+		adminKubeconfig = &config.AdminKubeconfigConfig{
+			CertLifetime: *args.CertLifetime,
+		}
+	}
+
 	configPatch := config.TalosConfig{
 		Cluster: &config.ClusterConfig{
 			ExternalCloudProvider: &config.ExternalCloudProviderConfig{
@@ -53,6 +62,7 @@ func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) {
 				Enabled: true, // Enable discovery, required for network encryption via kube span
 			},
 			AllowSchedulingOnControlPlanes: args.AllowSchedulingOnControlPlanes,
+			AdminKubeconfig:                adminKubeconfig,
 		},
 		Machine: &config.MachineConfig{
 			Type:            string(args.ServerNodeType),


### PR DESCRIPTION
Introduce CertLifetime field in TalosConfig and NodeConfigurationArgs to specify the duration of the admin kubeconfig certificate. This allows for more flexible certificate management.