### PR TITLE
chore: Add support for extra and inline Kubernetes manifests in TalosConfig

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -2,9 +2,6 @@ config:
   hcloud-k8s:talos:
     image_version: v1.10.5
     kubernetes_version: "1.33.0"
-    extra_manifests:
-      # Install Argocd from https://github.com/argoproj/argo-cd/tree/stable/manifests
-      - "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/namespace-install.yaml"
   hcloud-k8s:network:
     nameservers:
       # Quad9 DNS

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -2,6 +2,8 @@ config:
   hcloud-k8s:talos:
     image_version: v1.10.5
     kubernetes_version: "1.33.0"
+    extra_manifests:
+      - "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"
   hcloud-k8s:network:
     nameservers:
       # Quad9 DNS

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -3,7 +3,8 @@ config:
     image_version: v1.10.5
     kubernetes_version: "1.33.0"
     extra_manifests:
-      - "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"
+      # Install Argocd from https://github.com/argoproj/argo-cd/tree/stable/manifests
+      - "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/namespace-install.yaml"
   hcloud-k8s:network:
     nameservers:
       # Quad9 DNS

--- a/Pulumi.longhorn.yaml
+++ b/Pulumi.longhorn.yaml
@@ -17,14 +17,12 @@ config:
     node_pools:
       - count: 1
         server_size: cax11
-        arch: arm64
         region: hel1
   hcloud-k8s:node_pools:
     node_pools:
       - name: worker
         count: 3
         server_size: cax31
-        arch: arm64
         region: fsn1
   hcloud-k8s:kubernetes:
     hetzner_ccm:

--- a/pkg/config/talos.go
+++ b/pkg/config/talos.go
@@ -46,6 +46,14 @@ type PEMEncodedCertificateAndKey struct {
 	Key string `json:"key"`
 }
 
+// ClusterInlineManifest represents an inline Kubernetes manifest.
+type ClusterInlineManifest struct {
+	// Name of the manifest.
+	Name string `json:"name" validate:"required"`
+	// Manifest contents as a string.
+	Contents string `json:"contents" validate:"required"`
+}
+
 // TalosConfig contains all Talos Linux image & version settings.
 type TalosConfig struct {
 	// If set, overrides the ID of the Talos image on Hetzner
@@ -106,4 +114,23 @@ type TalosConfig struct {
 	// Note: When modifying this value, it is recommended to also update K8sCertificateRenewalDuration
 	// to ensure certificates are renewed well before the kubeconfig expires.
 	CertLifetime *string `json:"cert_lifetime" validate:"omitempty"`
+
+	// ExtraManifests is a list of URLs that point to additional manifests.
+	// These will get automatically deployed as part of the bootstrap.
+	// Examples:
+	//
+	//	- "https://www.example.com/manifest1.yaml"
+	//	- "https://www.example.com/manifest2.yaml"
+	ExtraManifests []string `json:"extra_manifests"`
+
+	// ExtraManifestHeaders is a map of key value pairs that will be added while fetching the ExtraManifests.
+	// Examples:
+	//
+	//	Token: "1234567"
+	//	X-ExtraInfo: "info"
+	ExtraManifestHeaders map[string]string `json:"extra_manifest_headers"`
+
+	// InlineManifests is a list of inline Kubernetes manifests.
+	// These will get automatically deployed as part of the bootstrap.
+	InlineManifests []ClusterInlineManifest `json:"inline_manifests"`
 }

--- a/pkg/hetzner/compute/nodepool.go
+++ b/pkg/hetzner/compute/nodepool.go
@@ -284,6 +284,7 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			NodeTaints:                     pool.Taints,
 			NodeAnnotations:                pool.Annotations,
 			Registries:                     cfg.Talos.Registries,
+			CertLifetime:                   cfg.Talos.CertLifetime,
 		})
 		if err != nil {
 			return nil, err
@@ -301,6 +302,7 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			NodeTaints:                     pool.Taints,
 			NodeAnnotations:                pool.Annotations,
 			Registries:                     cfg.Talos.Registries,
+			CertLifetime:                   cfg.Talos.CertLifetime,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/hetzner/compute/nodepool.go
+++ b/pkg/hetzner/compute/nodepool.go
@@ -285,6 +285,9 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			NodeAnnotations:                pool.Annotations,
 			Registries:                     cfg.Talos.Registries,
 			CertLifetime:                   cfg.Talos.CertLifetime,
+			ExtraManifests:                 cfg.Talos.ExtraManifests,
+			ExtraManifestHeaders:           cfg.Talos.ExtraManifestHeaders,
+			InlineManifests:                cfg.Talos.InlineManifests,
 		})
 		if err != nil {
 			return nil, err
@@ -303,6 +306,9 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			NodeAnnotations:                pool.Annotations,
 			Registries:                     cfg.Talos.Registries,
 			CertLifetime:                   cfg.Talos.CertLifetime,
+			ExtraManifests:                 cfg.Talos.ExtraManifests,
+			ExtraManifestHeaders:           cfg.Talos.ExtraManifestHeaders,
+			InlineManifests:                cfg.Talos.InlineManifests,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/talos/core/node-configuration.go
+++ b/pkg/talos/core/node-configuration.go
@@ -40,6 +40,14 @@ type NodeConfigurationArgs struct {
 	EnableLocalStorage bool
 	// Registries is the registries configuration for the Talos image
 	Registries *core_config.RegistriesConfig
+	// ExtraManifests is a list of URLs that point to additional manifests
+	// These will get automatically deployed as part of the bootstrap
+	ExtraManifests []string
+	// ExtraManifestHeaders is a map of key value pairs that will be added while fetching the ExtraManifests
+	ExtraManifestHeaders map[string]string
+	// InlineManifests is a list of inline Kubernetes manifests
+	// These will get automatically deployed as part of the bootstrap
+	InlineManifests []core_config.ClusterInlineManifest
 }
 
 func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) {
@@ -63,6 +71,9 @@ func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) {
 			},
 			AllowSchedulingOnControlPlanes: args.AllowSchedulingOnControlPlanes,
 			AdminKubeconfig:                adminKubeconfig,
+			ExtraManifests:                 args.ExtraManifests,
+			ExtraManifestHeaders:           args.ExtraManifestHeaders,
+			InlineManifests:                toInlineManifests(args.InlineManifests),
 		},
 		Machine: &config.MachineConfig{
 			Type:            string(args.ServerNodeType),
@@ -219,5 +230,16 @@ func toRegistriesConfig(args *core_config.RegistriesConfig) *config.RegistriesCo
 		}
 	}
 
+	return out
+}
+
+func toInlineManifests(manifests []core_config.ClusterInlineManifest) []config.ClusterInlineManifest {
+	out := make([]config.ClusterInlineManifest, len(manifests))
+	for i, manifest := range manifests {
+		out[i] = config.ClusterInlineManifest{
+			Name:     manifest.Name,
+			Contents: manifest.Contents,
+		}
+	}
 	return out
 }


### PR DESCRIPTION
Introduce support for extra and inline Kubernetes manifests in TalosConfig and node configuration. Update Argo CD manifest URL and add unit tests for inline manifests processing. Remove architecture specification from node pools and adjust deployment configuration accordingly.