### PR TITLE
chore: Refactor Talos configuration and add CNI support

### DIFF
--- a/pkg/config/talos.go
+++ b/pkg/config/talos.go
@@ -160,7 +160,4 @@ type TalosConfig struct {
 
 	// CNI configuration for the cluster.
 	CNI *CNIConfig `json:"cni"`
-
-	// Proxy configuration for the cluster.
-	Proxy *ProxyConfig `json:"proxy"`
 }

--- a/pkg/hetzner/compute/nodepool.go
+++ b/pkg/hetzner/compute/nodepool.go
@@ -295,7 +295,6 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			EnableHetznerCCMExtraManifest:  cfg.Talos.EnableHetznerCCMExtraManifest,
 			EnableKubeSpan:                 cfg.Talos.EnableKubeSpan,
 			CNI:                            cfg.Talos.CNI,
-			Proxy:                          cfg.Talos.Proxy,
 		})
 		if err != nil {
 			return nil, err
@@ -320,7 +319,6 @@ func DeployControlPlanePools(ctx *pulumi.Context, cfg *config.PulumiConfig, imag
 			EnableHetznerCCMExtraManifest:  cfg.Talos.EnableHetznerCCMExtraManifest,
 			EnableKubeSpan:                 cfg.Talos.EnableKubeSpan,
 			CNI:                            cfg.Talos.CNI,
-			Proxy:                          cfg.Talos.Proxy,
 		})
 		if err != nil {
 			return nil, err
@@ -384,7 +382,6 @@ func DeployWorkerPools(ctx *pulumi.Context, cfg *config.PulumiConfig, images *im
 			Registries:            cfg.Talos.Registries,
 			EnableKubeSpan:        cfg.Talos.EnableKubeSpan,
 			CNI:                   cfg.Talos.CNI,
-			Proxy:                 cfg.Talos.Proxy,
 		})
 		if err != nil {
 			return nil, err
@@ -402,7 +399,6 @@ func DeployWorkerPools(ctx *pulumi.Context, cfg *config.PulumiConfig, images *im
 			Registries:            cfg.Talos.Registries,
 			EnableKubeSpan:        cfg.Talos.EnableKubeSpan,
 			CNI:                   cfg.Talos.CNI,
-			Proxy:                 cfg.Talos.Proxy,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/k8s/charts/autoscaler/cluster-autoscaler.go
+++ b/pkg/k8s/charts/autoscaler/cluster-autoscaler.go
@@ -36,8 +36,6 @@ type ClusterAutoscalerArgs struct {
 	EnableKubeSpan bool
 	// CNI is the CNI configuration for the cluster.
 	CNI *config.CNIConfig
-	// Proxy is the proxy configuration for the cluster.
-	Proxy *config.ProxyConfig
 }
 
 type ClusterAutoscaler struct {
@@ -72,7 +70,6 @@ func NewClusterAutoscaler(ctx *pulumi.Context, args *ClusterAutoscalerArgs, opts
 			EnableKubeSpan:        args.EnableKubeSpan,
 			BootstrapEnable:       true,
 			CNI:                   args.CNI,
-			Proxy:                 args.Proxy,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/k8s/cluster/applications.go
+++ b/pkg/k8s/cluster/applications.go
@@ -125,7 +125,6 @@ func NewApplications(ctx *pulumi.Context, name string, args *ApplicationsArgs, o
 			Firewall:                    args.FirewallWorker,
 			EnableKubeSpan:              args.Cfg.Talos.EnableKubeSpan,
 			CNI:                         args.Cfg.Talos.CNI,
-			Proxy:                       args.Cfg.Talos.Proxy,
 		},
 			opts...,
 		)

--- a/pkg/talos/core/node-configuration.go
+++ b/pkg/talos/core/node-configuration.go
@@ -54,8 +54,6 @@ type NodeConfigurationArgs struct {
 	EnableKubeSpan bool
 	// CNI is the CNI configuration for the cluster.
 	CNI *core_config.CNIConfig
-	// Proxy is the proxy configuration for the cluster.
-	Proxy *core_config.ProxyConfig
 }
 
 func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) { //nolint:funlen
@@ -84,7 +82,6 @@ func NewNodeConfiguration(args *NodeConfigurationArgs) (string, error) { //nolin
 				PodSubnets: []string{args.PodSubnets},
 				CNI:        toCNIConfig(args.CNI),
 			},
-			Proxy: toProxyConfig(args.Proxy),
 			Discovery: &config.ClusterDiscoveryConfig{
 				Enabled: true, // Enable discovery, required for network encryption via kube span
 			},
@@ -194,16 +191,6 @@ func toCNIConfig(cni *core_config.CNIConfig) *config.CNIConfig {
 	return &config.CNIConfig{
 		Name: cni.Name,
 		URLs: cni.URLs,
-	}
-}
-
-func toProxyConfig(proxy *core_config.ProxyConfig) *config.ProxyConfig {
-	if proxy == nil {
-		return nil
-	}
-
-	return &config.ProxyConfig{
-		Disabled: proxy.Disabled,
 	}
 }
 


### PR DESCRIPTION
Remove unnecessary Proxy configuration and default validation for EnableKubeSpan in TalosConfig. Introduce FeaturesConfig with ImageCache and HostDNS settings, and add support for CNI and Proxy configurations. EnableKubeSpan option added for traffic encryption.